### PR TITLE
Improve G1GC accounting for humongous objects

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -761,7 +761,8 @@ private:
   HeapWord* do_collection_pause(size_t         word_size,
                                 uint           gc_count_before,
                                 bool*          succeeded,
-                                GCCause::Cause gc_cause);
+                                GCCause::Cause gc_cause,
+                                bool           force_gc);
 
   void wait_for_root_region_scanning();
 

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -69,6 +69,8 @@ G1Policy::G1Policy(STWGCTimer* gc_timer) :
   _reserve_regions(0),
   _young_gen_sizer(),
   _free_regions_at_end_of_collection(0),
+  _predicted_survival_bytes_from_survivor(0),
+  _predicted_survival_bytes_from_old(0),
   _rs_length(0),
   _rs_length_prediction(0),
   _pending_cards_at_gc_start(0),
@@ -451,6 +453,7 @@ void G1Policy::record_full_collection_end() {
   // also call this on any additional surv rate groups
 
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
+  calculate_required_regions_for_next_collect();
   _survivor_surv_rate_group->reset();
   update_young_list_max_and_target_length();
   update_rs_length_prediction();
@@ -781,6 +784,9 @@ void G1Policy::record_collection_pause_end(double pause_time_ms, bool concurrent
   _free_regions_at_end_of_collection = _g1h->num_free_regions();
 
   update_rs_length_prediction();
+
+  // Is this the right place? Should it be in the below?
+  calculate_required_regions_for_next_collect();
 
   // Do not update dynamic IHOP due to G1 periodic collection as it is highly likely
   // that in this case we are not running in a "normal" operating mode.
@@ -1439,6 +1445,63 @@ void G1Policy::calculate_optional_collection_set_regions(G1CollectionSetCandidat
 
   log_debug(gc, ergo, cset)("Prepared %u regions out of %u for optional evacuation. Predicted time: %.3fms",
                             num_optional_regions, max_optional_regions, prediction_ms);
+}
+
+bool G1Policy::can_mutator_consume_free_regions(uint alloc_region_count) {
+  uint eden_count = _g1h->eden_regions_count();
+  if (eden_count < 1) {
+    return true;
+  }
+  size_t const predicted_survival_bytes_from_eden = _eden_surv_rate_group->accum_surv_rate_pred(eden_count) * HeapRegion::GrainBytes;
+  size_t const total_predicted_survival_bytes = predicted_survival_bytes_from_eden + _predicted_survival_bytes_from_survivor + _predicted_survival_bytes_from_old;
+  // adjust the total survival bytes by the target amount of wasted space in PLABs.
+  // should old bytes be adjusted and turned into a region count on its own?
+  size_t const adjusted_survival_bytes_bytes = (size_t)(total_predicted_survival_bytes * (100 + TargetPLABWastePct) / 100.0);
+
+  uint required_regions = ceil((double)adjusted_survival_bytes_bytes / (double)HeapRegion::GrainBytes);
+  if (required_regions <= _g1h->num_free_regions() - alloc_region_count) {
+    return true;
+  }
+  log_debug(gc, ergo, cset)("Forcing GC, insufficient free regions for GC predicted %u current eden %u (%u) survivor %u (%u) old %u (%u) free %u alloc %u",
+          required_regions,
+          eden_count,
+          (uint)(predicted_survival_bytes_from_eden / HeapRegion::GrainBytes),
+          _g1h->survivor_regions_count(),
+          (uint)(_predicted_survival_bytes_from_survivor / HeapRegion::GrainBytes),
+          _g1h->old_regions_count(),
+          (uint)(_predicted_survival_bytes_from_old / HeapRegion::GrainBytes),
+          _g1h->num_free_regions(),
+          alloc_region_count);
+  return false;
+}
+
+void G1Policy::calculate_required_regions_for_next_collect() {
+  // calculate the survival bytes from survivor in the next GC
+  size_t survivor_bytes = 0;
+  const GrowableArray<HeapRegion*>* survivor_regions = _g1h->survivor()->regions();
+  for (GrowableArrayIterator<HeapRegion*> it = survivor_regions->begin();
+       it != survivor_regions->end();
+       ++it) {
+
+    survivor_bytes += predict_bytes_to_copy(*it);
+  }
+  _predicted_survival_bytes_from_survivor = survivor_bytes;
+
+  // calculate the survival bytes from old in the next GC
+  _predicted_survival_bytes_from_old = 0;
+  G1CollectionSetCandidates *candidates = _collection_set->candidates();
+  if ((candidates != NULL) && !candidates->is_empty()) {
+    uint predicted_old_region_count = calc_min_old_cset_length();
+    uint num_remaining = candidates->num_remaining();
+    uint iterate_count = num_remaining < predicted_old_region_count ? num_remaining : predicted_old_region_count;
+    uint current_index = candidates->cur_idx();
+    size_t old_bytes = 0;
+    for (uint i = 0; i < iterate_count; i++) {
+      HeapRegion *region = candidates->at(current_index + i);
+      old_bytes += predict_bytes_to_copy(region);
+    }
+    _predicted_survival_bytes_from_old = old_bytes;
+  }
 }
 
 void G1Policy::transfer_survivors_to_cset(const G1SurvivorRegions* survivors) {

--- a/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -98,6 +98,9 @@ class G1Policy: public CHeapObj<mtGC> {
 
   uint _free_regions_at_end_of_collection;
 
+  size_t _predicted_survival_bytes_from_survivor;
+  size_t _predicted_survival_bytes_from_old;
+
   size_t _rs_length;
 
   size_t _rs_length_prediction;
@@ -362,6 +365,8 @@ public:
                                                  double time_remaining_ms,
                                                  uint& num_optional_regions);
 
+  bool can_mutator_consume_free_regions(uint region_count);
+  void calculate_required_regions_for_next_collect();
 private:
   // Set the state to start a concurrent marking cycle and clear
   // _initiate_conc_mark_if_possible because it has now been

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -106,9 +106,11 @@ void VM_G1TryInitiateConcMark::doit() {
 VM_G1CollectForAllocation::VM_G1CollectForAllocation(size_t         word_size,
                                                      uint           gc_count_before,
                                                      GCCause::Cause gc_cause,
-                                                     double         target_pause_time_ms) :
+                                                     double         target_pause_time_ms,
+                                                     bool           force_gc) :
   VM_CollectForAllocation(word_size, gc_count_before, gc_cause),
   _gc_succeeded(false),
+  _force_gc(force_gc),
   _target_pause_time_ms(target_pause_time_ms) {
 
   guarantee(target_pause_time_ms > 0.0,
@@ -120,7 +122,7 @@ VM_G1CollectForAllocation::VM_G1CollectForAllocation(size_t         word_size,
 void VM_G1CollectForAllocation::doit() {
   G1CollectedHeap* g1h = G1CollectedHeap::heap();
 
-  if (_word_size > 0) {
+  if (_word_size > 0 && !_force_gc) {
     // An allocation has been requested. So, try to do that first.
     _result = g1h->attempt_allocation_at_safepoint(_word_size,
                                                    false /* expect_null_cur_alloc_region */);

--- a/src/hotspot/share/gc/g1/g1VMOperations.hpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.hpp
@@ -68,13 +68,15 @@ public:
 
 class VM_G1CollectForAllocation : public VM_CollectForAllocation {
   bool _gc_succeeded;
+  bool _force_gc;
   double _target_pause_time_ms;
 
 public:
   VM_G1CollectForAllocation(size_t         word_size,
                             uint           gc_count_before,
                             GCCause::Cause gc_cause,
-                            double         target_pause_time_ms);
+                            double         target_pause_time_ms,
+                            bool           force_gc = false);
   virtual VMOp_Type type() const { return VMOp_G1CollectForAllocation; }
   virtual void doit();
   bool gc_succeeded() const { return _gc_succeeded; }

--- a/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
+++ b/test/hotspot/jtreg/gc/g1/TestGCLogMessages.java
@@ -313,16 +313,17 @@ public class TestGCLogMessages {
     static class GCTestWithEvacuationFailure {
         private static byte[] garbage;
         private static byte[] largeObject;
-        private static Object[] holder = new Object[200]; // Must be larger than G1EvacuationFailureALotCount
+        private static Object[] holder = new Object[800]; // Must be larger than G1EvacuationFailureALotCount
 
         public static void main(String [] args) {
             largeObject = new byte[16*1024*1024];
             System.out.println("Creating garbage");
-            // Create 16 MB of garbage. This should result in at least one GC,
+            // Create 64 MB of garbage. This should result in at least one GC,
             // (Heap size is 32M, we use 17MB for the large object above)
-            // which is larger than G1EvacuationFailureALotInterval.
+            // which is larger than G1EvacuationFailureALotInterval and enough
+            // will survive to cause the evacuation failure.
             for (int i = 0; i < 16 * 1024; i++) {
-                holder[i % holder.length] = new byte[1024];
+                holder[i % holder.length] = new byte[4096];
             }
             System.out.println("Done");
         }


### PR DESCRIPTION
If there is a burst of humongous allocations they can
consume all of the free regions left in the heap. If
there are no free regions for to-space a collect will
fail to evacuate all objects. This makes the GC very
slow. Since, humongous regions can be collected in
G1GC young collects force a young collect before the
number of free regions becomes less than the number
the GC is likely to require.

Signed-off-by: Charlie Gracie <charlie.gracie@microsoft.com>